### PR TITLE
install_binding-pry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,9 @@ group :development, :test do
   gem 'capistrano-bundler'
   gem 'capistrano-rails'
   gem 'capistrano3-unicorn'
+  gem 'pry-rails'
+  gem 'pry-byebug'
+  gem 'pry-doc'
 end
 
 group :development do


### PR DESCRIPTION
#what
binding-pryの導入

#why
binding.pry で処理を止めてステップ実行ができるようにするため