### PR TITLE
haml修正・商品出品機能実装

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,7 +2,7 @@ class Item < ApplicationRecord
   has_many_attached :images
   belongs_to :user, optional: true
   # accepts_nested_attributes_for :brand
-
+  enum category:  {'選択してください':0,'レディース':1, 'ベビー・キッズ':2,'インテリア・住まい・小物':3,'本音楽・ゲーム':4,'おもちゃ・ホビー・グッズ':5,'コスメ・香水・美容':6,'家電・スマホ・カメラ':7,'スポーツ・レジャー':8,'ハンドメイド':9,'チケット':10,'自転車・オートバイ':11,'その他':12},_suffix: true
   enum shipping_date:  {'選択してください':0,'1~2日で配送':1, '2~3日で配送':2,'4~7日で配送':3},_suffix: true
   enum shipping_method:  {'選択してください':0,'未定':1, 'らくらくメルカリ便':2,'ゆうメール':3, 'レターパック': 4, '普通郵便（定形、定形外）':5, 'クロネコヤマト': 6, 'ゆうパック': 7, 'クリックポスト':8, 'ゆうパケット': 9},_suffix: true
   enum postage:  {'選択してください':0,'送料込み（出品者負担）':1, '着払い（購入者負担）':2},_suffix: true

--- a/app/views/sells/index.html.haml
+++ b/app/views/sells/index.html.haml
@@ -51,7 +51,7 @@
                       .sells__select__wrap
                         %i.sells__icon__arrow
                         -# %select.sells__select__default
-                        = f.select :category_id, [['選択してください',1],['レディース',2]], { autofocus: 'true'}, {class:"sells__select__default"}
+                        = f.select :category_id, Item.categories.keys.to_a, { autofocus: 'true'}, {class:"sells__select__default"}
                         .sells__error__message 選択してください
                       .sells__select__wrap
                         %i.sells__icon__arrow

--- a/spec/controllers/sells_controller.rb
+++ b/spec/controllers/sells_controller.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+Rspec.describe "SellsController", type: :controller do
+  
+  def create
+    @item = Item.new(item_params) 
+    if @item.save
+      redirect_to root_path, notice: '商品を出品しました'
+    else
+      render :new
+    end
+  end
+end

--- a/spec/factories/sells.rb
+++ b/spec/factories/sells.rb
@@ -1,0 +1,17 @@
+FactoryBot.define do
+  factory :product do
+
+id                    {1}
+user_id               {4}
+products              {"シャツ"}
+description_of_item   {"返品受け付けません"}
+price                 {"3000"}
+size                  {12}
+shipping_date         {1}
+shipping_method       {2}
+postage               {1}
+shipping_origin       {3}
+condition             {1}
+  
+  end
+end

--- a/spec/models/sell_spec.rb
+++ b/spec/models/sell_spec.rb
@@ -1,0 +1,121 @@
+require 'rails_helper'
+
+describe Item do
+  describe '#create' do
+    it "全て揃っている時保存できる" do
+        item = build(:item)
+        expect(item).to be_valid
+    end
+    
+    #空の場合のテスト
+    # it "is invalid without a images" do
+    #     item = build(:item, images:[] )
+    #     item.valid?
+    #     expect(item.errors[:images]).to include("を入力してください")
+    # end
+
+    it "is invalid without a products" do
+        item = build(:item, products: "")
+        item.valid?
+        expect(item.errors[:products]).to include("を入力してください")
+    end
+
+    it "is invalid without a description_of_item" do
+        item = build(:item description_of_item: "")
+        item.valid?
+        expect(item.errors[:description_of_item]).to include("を入力してください")
+    end
+
+    it "is invalid without a price" do
+        item = build(:item, price: "")
+        item.valid?
+        expect(item.errors[:price]).to include("を入力してください")
+    end
+
+    it "is invalid without a condition_id" do
+        item = build(:item, size: "")
+        item.valid?
+        expect(item.errors[:size]).to include("を入力してください")
+    end
+
+    it "is invalid without a delivery_charge_id" do
+        item = build(:item, shipping_method: "")
+        item.valid?
+        expect(item.errors[:shipping_method]).to include("を入力してください")
+    end
+
+    it "is invalid without a prefecture_id" do
+        item = build(:item, prefecture_id: "")
+        item.valid?
+        expect(item.errors[:prefecture_id]).to include("を入力してください")
+    end
+
+    it "is invalid without a delivery_days_id" do
+        item = build(:item, delivery_days_id: "")
+        item.valid?
+        expect(item.errors[:delivery_days_id]).to include("を入力してください")
+    end
+
+    it "is invalid without a price" do
+        item = build(:item, price: "")
+        item.valid?
+        expect(item.errors[:price]).to include("を入力してください")
+    end
+
+    #nameの文字が40文字以上と以下の場合
+    it "is invalid name is too long maximum 40 characters" do
+        item = build(:item, name: "a" * 41)
+        item.valid?
+        expect(item.errors[:name]).to include("は40文字以内で入力してください")
+    end
+
+    it "is valid with a name that has less than 40 characters" do
+        item = build(:item, name: "a" * 39)
+        expect(item).to be_valid
+    end
+
+    #descriptionの文字が1000文字以上と以下の場合
+    it "is invalid description is too long maximum 40 characters" do
+        item = build(:item, description: "a" * 1001)
+        item.valid?
+        expect(item.errors[:description]).to include("は1000文字以内で入力してください")
+    end
+
+    it "is valid with a description that has less than 1000 characters" do
+        item = build(:item, description: "a" * 1000)
+        expect(item).to be_valid
+    end
+
+    #priceが9999999円以上の場合
+    it "is invalid price is too much maximum 9999999" do
+        item = build(:item, price: 10000000)
+        item.valid?
+        expect(item.errors[:price]).to include("は一覧にありません")
+    end
+
+    #priceが9999999円の場合
+    it "is valid price is too much maximum 9999999" do
+        item = build(:item, price: 9999999)
+        expect(item).to be_valid
+    end
+
+    #priceが300円以下の場合
+    it "is invalid with a that has less than 300" do
+        item = build(:item, price: 299)
+        item.valid?
+        expect(item.errors[:price]).to include("は一覧にありません")
+    end
+
+    #priceが300円の場合
+    it "is valid with a that has less than 300" do
+        item = build(:item, price: 300)
+        expect(item).to be_valid
+    end
+
+    #brandが無くても保存できる
+    it "is valid without a brand" do
+        item = build(:item, brand: "")
+        expect(item).to be_valid
+    end
+  end
+end


### PR DESCRIPTION
＃WHAT
商品出品機能の実装、S３への画像アップロード機能の実装
＃WHY
メルカリクローンアプリでローカル環境・本番環境で商品出品ができるようにするため。
本番環境では、画像をS3に保存できるようにするため。

以下、出品後の詳細ページ、商品購入機能の実装に必要であったため、ローカル環境でのみの商品機能実装完了後マージ済み
https://github.com/kakiharahiroaki/freemarket_sample_64-b/commit/498cce705d9f0640d105650a89713a0b6bf75fb2

単体テストは、時間に余裕がある時に実装する予定です。