### PR TITLE
出品商品削除

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -7,5 +7,11 @@ class ItemsController < ApplicationController
     @items = Item.where(user_id: @item.user.id).includes(:user).limit(6).order("created_at DESC")
   end
 
-  
+  def destroy
+    @item = Item.find(params[:id])
+     if @item.user_id == current_user.id
+      @item.destroy #destroyメソッドを使用し対象のツイートを削除する。
+      redirect_to root_path
+     end
+   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -9,9 +9,9 @@ class ItemsController < ApplicationController
 
   def destroy
     @item = Item.find(params[:id])
-      if @item.user_id == current_user.id
-        @item.destroy #destroyメソッドを使用し対象のツイートを削除する。
+    if @item.user_id == current_user.id
+      @item.destroy #destroyメソッドを使用し対象のツイートを削除する。
       redirect_to root_path
-     end
-   end
+    end
+  end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -9,8 +9,8 @@ class ItemsController < ApplicationController
 
   def destroy
     @item = Item.find(params[:id])
-     if @item.user_id == current_user.id
-      @item.destroy #destroyメソッドを使用し対象のツイートを削除する。
+      if @item.user_id == current_user.id
+        @item.destroy #destroyメソッドを使用し対象のツイートを削除する。
       redirect_to root_path
      end
    end

--- a/app/views/items/_show_items_container.html.haml
+++ b/app/views/items/_show_items_container.html.haml
@@ -85,7 +85,8 @@
       %form
         %input{type: "hidden"}
         %button.btn__default.btn__gray{type: "submit"} 出品を停止する
-      %button.btn__default.btn__gray この商品を削除する
+      
+      = link_to 'この商品を削除する', "/items/#{@item.id}", class:"btn__default btn__gray", method: :delete
   -else
     =link_to "購入画面に進む", buys_index_path, class: "item__btn"
     %p.error__message この商品はゆうゆうメルカリ便を利用しているため、アプリからのみ購入できます。

--- a/app/views/items/_show_items_container.html.haml
+++ b/app/views/items/_show_items_container.html.haml
@@ -84,9 +84,8 @@
       %p.text__center or
       %form
         %input{type: "hidden"}
-        %button.btn__default.btn__gray{type: "submit"} 出品を停止する
-      
-      = link_to 'この商品を削除する', "/items/#{@item.id}", class:"btn__default btn__gray", method: :delete
+        %button.btn__default.btn__gray{type: "submit"} 出品を停止する   
+      = link_to 'この商品を削除する', item_path(@item.id), class:"btn__default btn__gray", method: :delete
   -else
     =link_to "購入画面に進む", buys_index_path, class: "item__btn"
     %p.error__message この商品はゆうゆうメルカリ便を利用しているため、アプリからのみ購入できます。

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,8 @@ Rails.application.routes.draw do
   get "/users/destroy", to: "users#destroy"
   get  "/users/show", to: "users#show"
   
-  resources :items, only: [:index, :new, :create, :show]
+  resources :items, only: [:index, :new, :create, :show, :destroy]
+  # delete 'items/:id' => 'items#destroy'
   resources :sells, only: :create
   resources :users, only: [:create, :destroy, :show, :update] do
     collection do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,6 @@ Rails.application.routes.draw do
   get  "/users/show", to: "users#show"
   
   resources :items, only: [:index, :new, :create, :show, :destroy]
-  # delete 'items/:id' => 'items#destroy'
   resources :sells, only: :create
   resources :users, only: [:create, :destroy, :show, :update] do
     collection do


### PR DESCRIPTION
#WHAT
出品された商品の削除機能の実装
＃WHY
出品者が出品した自分の商品を削除できるようにするため

＃挙動
usersテーブル
https://gyazo.com/17636c62a996077905f3711b50d2674b
itemsテーブル
https://gyazo.com/b7f82b7269a8ae3b36244953c88d9c38

・田中でログインした場合
田中さんの商品ページにアクセス
https://gyazo.com/91708d187cce01401c448a8383203aae
柿原さんの商品ページにアクセス
https://gyazo.com/86e3d209337f12b4ce0e742aa12e6df5

・削除ボタンの実行
https://gyazo.com/430e67154c3eb04dddb675b4a93e0750
https://gyazo.com/79778f71df5344380abe80ffb5981811


単体テストは時間がある時に実装します。